### PR TITLE
Set example format text to white for clarity

### DIFF
--- a/docs/notion-setup-tutorial.html
+++ b/docs/notion-setup-tutorial.html
@@ -291,6 +291,10 @@
         display: inline-block;
       }
 
+      .callout .code {
+        color: #ffffff;
+      }
+
       .timeline {
         display: grid;
         gap: 1.2rem;


### PR DESCRIPTION
## Summary
- ensure the example format text in the Notion setup tutorial displays in white for better readability

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951dbd9aee48333a1071657233f7491)