### PR TITLE
Redesign Notion setup tutorial page

### DIFF
--- a/docs/notion-setup-tutorial.html
+++ b/docs/notion-setup-tutorial.html
@@ -6,18 +6,20 @@
     <title>Notion 配置教程 - Tweet Craft</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fraunces:wght@500;600;700&family=IBM+Plex+Mono:wght@400;500&family=Sora:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@500;600;700&family=Manrope:wght@400;500;600&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
     <style>
       :root {
-        --ink: #0f172a;
-        --muted: rgba(15, 23, 42, 0.7);
-        --paper: #f8f6f2;
-        --panel: rgba(255, 255, 255, 0.85);
-        --accent: #ff7849;
-        --accent-2: #2ec4b6;
-        --accent-3: #f6c453;
-        --line: rgba(15, 23, 42, 0.12);
-        --shadow: 0 24px 60px rgba(15, 23, 42, 0.15);
+        --ink: #e7f8ff;
+        --muted: rgba(231, 248, 255, 0.78);
+        --paper: #0c111c;
+        --panel: rgba(9, 14, 24, 0.8);
+        --glass: rgba(255, 255, 255, 0.06);
+        --accent: #79ffe1;
+        --accent-2: #ff8ad8;
+        --accent-3: #ffd166;
+        --line: rgba(255, 255, 255, 0.16);
+        --shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
+        --glare: linear-gradient(135deg, rgba(121, 255, 225, 0.18), rgba(255, 138, 216, 0.18));
       }
 
       * {
@@ -26,40 +28,56 @@
 
       body {
         margin: 0;
-        font-family: 'Sora', sans-serif;
+        font-family: 'Manrope', 'Helvetica Neue', Arial, sans-serif;
         color: var(--ink);
-        background: radial-gradient(circle at top, #1b263b, #0b1220 55%);
+        background:
+          radial-gradient(circle at 18% 12%, rgba(121, 255, 225, 0.08), transparent 35%),
+          radial-gradient(circle at 80% 14%, rgba(255, 138, 216, 0.08), transparent 30%),
+          linear-gradient(160deg, #05070f, #0b1020 48%, #090c18);
+        min-height: 100vh;
+        position: relative;
+        overflow-x: hidden;
+      }
+
+      body::after {
+        content: '';
+        position: fixed;
+        inset: -10% -20%;
+        background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120" viewBox="0 0 120 120"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" stitchTiles="stitch"/></filter><rect width="120" height="120" filter="url(%23n)" opacity="0.17"/></svg>');
+        opacity: 0.7;
+        pointer-events: none;
         min-height: 100vh;
       }
 
       .page {
         position: relative;
-        padding: 3.5rem 1.5rem 5rem;
+        padding: 3.5rem 1.5rem 6rem;
         overflow: hidden;
       }
 
-      .page::before,
+      .page::before {
+        content: '';
+        position: absolute;
+        inset: -12% 6% auto auto;
+        width: 320px;
+        height: 320px;
+        background: radial-gradient(circle at 30% 30%, rgba(255, 138, 216, 0.22), transparent 55%),
+          radial-gradient(circle at 70% 70%, rgba(121, 255, 225, 0.2), transparent 55%);
+        filter: blur(12px);
+        opacity: 0.9;
+        transform: rotate(-8deg);
+      }
+
       .page::after {
         content: '';
         position: absolute;
-        inset: -20% 0 0;
-        background-image:
-          radial-gradient(circle at 15% 25%, rgba(255, 120, 73, 0.25), transparent 45%),
-          radial-gradient(circle at 80% 10%, rgba(46, 196, 182, 0.2), transparent 40%),
-          radial-gradient(circle at 70% 85%, rgba(246, 196, 83, 0.2), transparent 35%);
-        z-index: 0;
-        animation: float 14s ease-in-out infinite;
-      }
-
-      .page::after {
-        mix-blend-mode: screen;
-        opacity: 0.6;
-      }
-
-      @keyframes float {
-        0% { transform: translateY(0); }
-        50% { transform: translateY(14px); }
-        100% { transform: translateY(0); }
+        inset: auto 5% -18% -10%;
+        height: 320px;
+        background:
+          linear-gradient(120deg, rgba(121, 255, 225, 0.16), transparent 35%),
+          linear-gradient(-130deg, rgba(255, 209, 102, 0.14), transparent 40%);
+        transform: skewY(-6deg);
+        opacity: 0.8;
       }
 
       main {
@@ -67,94 +85,129 @@
         z-index: 1;
         max-width: 1100px;
         margin: 0 auto;
-        background: var(--panel);
-        border-radius: 28px;
-        border: 1px solid rgba(255, 255, 255, 0.6);
+        background: linear-gradient(145deg, rgba(12, 17, 28, 0.92), rgba(9, 14, 24, 0.86));
+        border-radius: 32px;
+        border: 1px solid var(--glass);
         box-shadow: var(--shadow);
         overflow: hidden;
+        backdrop-filter: blur(12px);
+      }
+
+      .grid-overlay {
+        position: absolute;
+        inset: 0;
+        background-image:
+          linear-gradient(to right, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+          linear-gradient(to bottom, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+        background-size: 40px 40px;
+        pointer-events: none;
+        mask-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(255, 255, 255, 0));
       }
 
       header {
-        padding: 3.5rem;
+        position: relative;
+        padding: 3.8rem;
         display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-        gap: 2.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 2.8rem;
+        align-items: start;
+        background:
+          radial-gradient(circle at 14% 20%, rgba(121, 255, 225, 0.12), transparent 40%),
+          radial-gradient(circle at 80% 30%, rgba(255, 138, 216, 0.14), transparent 38%),
+          rgba(7, 11, 19, 0.78);
+        border-bottom: 1px solid var(--glass);
+      }
+
+      .header-topline {
+        display: flex;
         align-items: center;
-        background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.6));
+        gap: 0.8rem;
+        flex-wrap: wrap;
       }
 
       .badge {
         display: inline-flex;
         align-items: center;
-        gap: 0.6rem;
-        padding: 0.5rem 1rem;
-        border-radius: 999px;
-        background: rgba(46, 196, 182, 0.14);
-        color: #0f4c5c;
-        font-weight: 600;
+        gap: 0.5rem;
+        padding: 0.4rem 1rem;
+        border-radius: 12px;
+        background: var(--glass);
+        color: var(--accent);
+        font-weight: 700;
         font-size: 0.85rem;
-        letter-spacing: 0.08em;
+        letter-spacing: 0.12em;
         text-transform: uppercase;
+        border: 1px solid rgba(121, 255, 225, 0.4);
       }
 
       h1 {
-        font-family: 'Fraunces', serif;
-        font-size: clamp(2.4rem, 3.8vw, 3.6rem);
-        margin: 1rem 0 0.8rem;
-        letter-spacing: -0.02em;
+        font-family: 'Bricolage Grotesque', 'Manrope', sans-serif;
+        font-size: clamp(2.6rem, 4vw, 3.8rem);
+        margin: 1.3rem 0 0.3rem;
+        letter-spacing: -0.03em;
+        color: #f7fbff;
+        text-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
       }
 
       .lede {
         font-size: 1.05rem;
-        line-height: 1.8;
+        line-height: 1.9;
         color: var(--muted);
-        margin: 0 0 1.5rem;
+        margin: 0 0 1.6rem;
+        max-width: 620px;
       }
 
       .hero-tags {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.8rem;
+        gap: 0.75rem;
+        align-items: center;
       }
 
       .hero-tags span {
-        font-family: 'IBM Plex Mono', monospace;
-        font-size: 0.85rem;
-        padding: 0.4rem 0.8rem;
-        border-radius: 999px;
-        border: 1px dashed var(--line);
-        background: rgba(255, 255, 255, 0.7);
+        font-family: 'DM Mono', monospace;
+        font-size: 0.88rem;
+        padding: 0.4rem 0.9rem;
+        border-radius: 10px;
+        border: 1px solid var(--glass);
+        background: rgba(255, 255, 255, 0.06);
+        color: #c6e7ff;
+        letter-spacing: 0.01em;
+        box-shadow: 0 8px 30px rgba(0, 0, 0, 0.22);
       }
 
       .hero-card {
-        background: #101827;
-        color: #f8fafc;
-        padding: 2rem;
-        border-radius: 20px;
+        background: linear-gradient(160deg, rgba(12, 22, 39, 0.95), rgba(12, 22, 39, 0.72));
+        color: #f2fbff;
+        padding: 2.2rem;
+        border-radius: 22px;
         position: relative;
         overflow: hidden;
+        border: 1px solid rgba(121, 255, 225, 0.18);
+        box-shadow: 0 16px 50px rgba(0, 0, 0, 0.45);
       }
 
       .hero-card::after {
         content: '';
         position: absolute;
-        inset: 18% 12%;
-        border-radius: 16px;
-        border: 1px solid rgba(255, 255, 255, 0.2);
-        opacity: 0.6;
-        animation: pulse 4s ease-in-out infinite;
+        inset: 12% 8%;
+        border-radius: 18px;
+        border: 1px dashed rgba(255, 255, 255, 0.18);
+        opacity: 0.7;
+        animation: pulse 5s ease-in-out infinite;
       }
 
       @keyframes pulse {
-        0% { opacity: 0.2; }
-        50% { opacity: 0.6; }
-        100% { opacity: 0.2; }
+        0% { opacity: 0.2; transform: scale(0.98); }
+        50% { opacity: 0.75; transform: scale(1.01); }
+        100% { opacity: 0.2; transform: scale(0.98); }
       }
 
       .hero-card h2 {
         margin: 0 0 1rem;
-        font-family: 'Fraunces', serif;
-        font-size: 1.6rem;
+        font-family: 'Bricolage Grotesque', sans-serif;
+        font-size: 1.65rem;
+        letter-spacing: -0.01em;
       }
 
       .checklist {
@@ -169,54 +222,58 @@
         display: flex;
         align-items: flex-start;
         gap: 0.8rem;
-        font-size: 0.95rem;
-        line-height: 1.6;
+        font-size: 0.96rem;
+        line-height: 1.7;
       }
 
       .checklist li span {
         width: 24px;
         height: 24px;
         border-radius: 50%;
-        background: rgba(46, 196, 182, 0.25);
+        background: rgba(121, 255, 225, 0.18);
         display: inline-flex;
         align-items: center;
         justify-content: center;
         font-weight: 600;
-        color: #7dd3fc;
+        color: #79ffe1;
+        border: 1px solid rgba(121, 255, 225, 0.45);
       }
 
       section {
-        padding: 3.2rem 3.5rem;
-        border-top: 1px solid var(--line);
+        padding: 3.4rem 3.6rem;
+        border-top: 1px solid var(--glass);
       }
 
       h2 {
-        font-family: 'Fraunces', serif;
-        font-size: 2rem;
-        margin: 0 0 1.2rem;
+        font-family: 'Bricolage Grotesque', sans-serif;
+        font-size: 1.9rem;
+        margin: 0 0 1.15rem;
+        letter-spacing: -0.01em;
+        color: #f7fbff;
       }
 
       .section-lede {
         color: var(--muted);
         font-size: 1rem;
         margin-bottom: 1.8rem;
-        line-height: 1.8;
+        line-height: 1.85;
+        max-width: 760px;
       }
 
       .steps {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 1.5rem;
+        gap: 1.4rem;
       }
 
       .step-card {
-        background: var(--paper);
+        background: linear-gradient(180deg, rgba(16, 26, 43, 0.9), rgba(11, 17, 30, 0.92));
         border-radius: 18px;
         padding: 1.6rem;
-        border: 1px solid rgba(15, 23, 42, 0.1);
-        box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
-        min-height: 220px;
-        transform: translateY(16px);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+        min-height: 230px;
+        transform: translateY(18px);
         opacity: 0;
         animation: rise 0.7s ease forwards;
       }
@@ -240,14 +297,16 @@
         height: 36px;
         border-radius: 12px;
         font-weight: 600;
-        background: rgba(255, 120, 73, 0.15);
-        color: #a23b23;
+        background: rgba(255, 138, 216, 0.16);
+        color: #ffb0e7;
+        border: 1px solid rgba(255, 138, 216, 0.4);
         margin-bottom: 1rem;
       }
 
       .step-card h3 {
         margin: 0 0 0.6rem;
         font-size: 1.2rem;
+        color: #f3f9ff;
       }
 
       .step-card p {
@@ -266,13 +325,15 @@
       .callout {
         padding: 1.6rem;
         border-radius: 16px;
-        background: rgba(46, 196, 182, 0.1);
-        border: 1px solid rgba(46, 196, 182, 0.25);
+        background: linear-gradient(140deg, rgba(121, 255, 225, 0.12), rgba(12, 19, 33, 0.9));
+        border: 1px solid rgba(121, 255, 225, 0.3);
+        box-shadow: 0 12px 40px rgba(0, 0, 0, 0.24);
       }
 
       .callout h3 {
         margin: 0 0 0.6rem;
         font-size: 1.15rem;
+        color: #f4fbff;
       }
 
       .callout p {
@@ -282,17 +343,19 @@
       }
 
       .code {
-        font-family: 'IBM Plex Mono', monospace;
+        font-family: 'DM Mono', monospace;
         font-size: 0.9rem;
-        background: #0f172a;
-        color: #f8fafc;
-        padding: 0.8rem 1rem;
+        background: #05070f;
+        color: #79ffe1;
+        padding: 0.85rem 1.05rem;
         border-radius: 12px;
         display: inline-block;
+        border: 1px solid rgba(121, 255, 225, 0.35);
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.32);
       }
 
       .callout .code {
-        color: #ffffff;
+        color: #bdfef0;
       }
 
       .timeline {
@@ -307,25 +370,28 @@
         align-items: start;
         padding: 1.2rem;
         border-radius: 16px;
-        background: rgba(255, 255, 255, 0.7);
-        border: 1px solid rgba(15, 23, 42, 0.08);
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
       }
 
       .timeline-item span {
         width: 46px;
         height: 46px;
         border-radius: 14px;
-        background: rgba(246, 196, 83, 0.25);
+        background: rgba(255, 209, 102, 0.22);
         display: inline-flex;
         align-items: center;
         justify-content: center;
         font-weight: 600;
-        color: #a16207;
+        color: #ffd166;
+        border: 1px solid rgba(255, 209, 102, 0.32);
       }
 
       .timeline-item h4 {
         margin: 0 0 0.4rem;
-        font-size: 1.1rem;
+        font-size: 1.08rem;
+        color: #f6fbff;
       }
 
       .timeline-item p,
@@ -347,14 +413,16 @@
 
       details {
         border-radius: 14px;
-        border: 1px solid rgba(15, 23, 42, 0.12);
-        background: rgba(255, 255, 255, 0.75);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        background: rgba(255, 255, 255, 0.05);
         padding: 1rem 1.2rem;
+        box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
       }
 
       summary {
         font-weight: 600;
         cursor: pointer;
+        color: #f5fbff;
       }
 
       details p {
@@ -364,14 +432,14 @@
       }
 
       footer {
-        padding: 2.5rem 3.5rem 3rem;
+        padding: 2.8rem 3.6rem 3.2rem;
         display: flex;
         flex-wrap: wrap;
         gap: 1rem;
         justify-content: space-between;
         align-items: center;
-        border-top: 1px dashed var(--line);
-        background: rgba(248, 246, 242, 0.7);
+        border-top: 1px dashed var(--glass);
+        background: rgba(5, 7, 15, 0.9);
       }
 
       footer p {
@@ -382,6 +450,35 @@
 
       footer .code {
         font-size: 0.85rem;
+      }
+
+      .floating-line {
+        position: absolute;
+        inset: 10% 4% auto;
+        height: 1px;
+        background: linear-gradient(90deg, rgba(121, 255, 225, 0.2), rgba(255, 138, 216, 0.4), rgba(121, 255, 225, 0.2));
+        filter: drop-shadow(0 0 16px rgba(255, 138, 216, 0.3));
+        opacity: 0.8;
+      }
+
+      .micro-meta {
+        display: inline-flex;
+        gap: 0.6rem;
+        align-items: center;
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 12px;
+        padding: 0.45rem 0.7rem;
+        font-size: 0.9rem;
+        color: #c4e3ff;
+      }
+
+      .micro-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--accent-2);
+        box-shadow: 0 0 10px rgba(255, 138, 216, 0.6);
       }
 
       @media (max-width: 720px) {
@@ -407,9 +504,14 @@
   <body>
     <div class="page">
       <main>
+        <div class="grid-overlay"></div>
+        <div class="floating-line"></div>
         <header>
           <div>
-            <div class="badge">Tweet Craft × Notion</div>
+            <div class="header-topline">
+              <div class="badge">Tweet Craft × Notion</div>
+              <div class="micro-meta"><span class="micro-dot"></span>新手 6 分钟即用</div>
+            </div>
             <h1>Notion 配置教程</h1>
             <p class="lede">
               一次性把 Token、页面授权、数据库配置理顺。完成后点击推文的 Notion 按钮即可保存媒体、正文和链接。


### PR DESCRIPTION
## Summary
- refresh the Notion setup tutorial with a neon glassmorphism layout, new typography, and atmospheric accents
- refine cards, timeline, and FAQ styling for improved hierarchy and readability on dark background
- add subtle grid/line motifs and metadata badges to highlight quick-start context

## Testing
- not run (not necessary for static HTML changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e191f2f08333aee84eeb2d96d9bc)